### PR TITLE
feat: Add Homebrew support for easy CLI installation

### DIFF
--- a/Formula/legacy2modern-cli.rb
+++ b/Formula/legacy2modern-cli.rb
@@ -1,0 +1,20 @@
+class Legacy2modernCli < Formula
+  desc "AI-Powered Legacy Code Transpilation Engine with Modern CLI"
+  homepage "https://github.com/astrio-ai/legacy2modern"
+  url "https://github.com/astrio-ai/legacy2modern/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 ""  # This will be calculated when you create the release
+  license "Apache-2.0"
+  head "https://github.com/astrio-ai/legacy2modern.git", branch: "main"
+
+  depends_on "python@3.10"
+
+  def install
+    # Install the Python package
+    system "python3", "-m", "pip", "install", *std_pip_args, "."
+  end
+
+  test do
+    # Test that the CLI can be run
+    system "#{bin}/legacy2modern", "--help"
+  end
+end 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,17 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
-### Option 3: Run Directly (No Installation)
+### Option 3: Homebrew Installation (macOS)
+
+```bash
+# Install via Homebrew
+brew install legacy2modern-cli
+
+# Run the CLI
+legacy2modern
+```
+
+### Option 4: Run Directly (No Installation)
 
 ```bash
 # Clone the repository
@@ -125,6 +135,8 @@ l2m
 # Run directly without installation
 python run_cli.py
 ```
+
+**Note**: Homebrew installation provides the most convenient way to install and use the CLI on macOS.
 
 The CLI provides an interactive interface similar to Gemini CLI where you can:
 - Transpile COBOL files to Python using natural language commands

--- a/scripts/l2m
+++ b/scripts/l2m
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""
+Legacy2Modern CLI short command wrapper
+"""
+
+import sys
+import os
+
+# Add the project root to Python path
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, project_root)
+
+# Import and run the CLI
+from packages.cli.cli import main
+
+if __name__ == "__main__":
+    main() 

--- a/scripts/legacy2modern
+++ b/scripts/legacy2modern
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""
+Legacy2Modern CLI wrapper script
+"""
+
+import sys
+import os
+
+# Add the project root to Python path
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, project_root)
+
+# Import and run the CLI
+from packages.cli.cli import main
+
+if __name__ == "__main__":
+    main() 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,10 @@ setup(
             "l2m=packages.cli.cli:main",
         ],
     },
+    scripts=[
+        "scripts/legacy2modern",
+        "scripts/l2m",
+    ],
     include_package_data=True,
     zip_safe=False,
     keywords="cobol, transpiler, legacy, modernization, python, cli",


### PR DESCRIPTION
- Create Homebrew formula for legacy2modern-cli
- Add script wrappers for legacy2modern and l2m commands
- Update setup.py to include script entries
- Add Homebrew installation option to README
- Create comprehensive Homebrew setup documentation
- Enable users to install with: brew install legacy2modern-cli