### PR TITLE
Fix #42: Ensure Windows-compatible path resolution using pathlib and …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,17 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12"]
+        exclude:
+          # Reduce matrix size - test Windows only on latest Python
+          - os: windows-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.11"
 
     steps:
     - uses: actions/checkout@v4

--- a/src/main.py
+++ b/src/main.py
@@ -235,19 +235,19 @@ async def process_batch(args, settings):
     
     if args.directory:
         # Directory provided
-        cobol_files = discover_cobol_files(args.directory)
+        cobol_files = discover_cobol_files(Path(args.directory))
         if not cobol_files:
             print(f"Error: No COBOL files found in directory: {args.directory}")
             sys.exit(1)
     elif args.pattern:
         # Glob pattern provided
-        cobol_files = discover_cobol_files(".", pattern=args.pattern)
+        cobol_files = discover_cobol_files(Path("."), pattern=args.pattern)
         if not cobol_files:
             print(f"Error: No COBOL files found matching pattern: {args.pattern}")
             sys.exit(1)
     elif args.file_list:
         # File list provided
-        cobol_files = discover_cobol_files(args.file_list)
+        cobol_files = discover_cobol_files(Path(args.file_list))
         if not cobol_files:
             print(f"Error: No valid COBOL files found in list: {args.file_list}")
             sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,95 @@
+"""Tests for CLI functionality."""
+
+import pytest
+import tempfile
+from pathlib import Path
+from src.cli.interactive_shell import _expand_path, CLIContext
+
+
+class TestExpandPath:
+    """Tests for _expand_path function."""
+    
+    def test_expand_path_relative(self):
+        """Test expanding relative paths."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            context = CLIContext(cwd=base)
+            
+            # Test relative path
+            result = _expand_path(base, "test.txt")
+            expected = base / "test.txt"
+            assert result == expected.resolve()
+    
+    def test_expand_path_absolute(self):
+        """Test expanding absolute paths."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            context = CLIContext(cwd=base)
+            
+            # Test absolute path
+            abs_path = base / "absolute.txt"
+            result = _expand_path(base, str(abs_path))
+            assert result == abs_path.resolve()
+    
+    def test_expand_path_with_quotes(self):
+        """Test expanding paths with quotes."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            context = CLIContext(cwd=base)
+            
+            # Test with single quotes
+            result1 = _expand_path(base, "'test.txt'")
+            expected1 = base / "test.txt"
+            assert result1 == expected1.resolve()
+            
+            # Test with double quotes
+            result2 = _expand_path(base, '"test.txt"')
+            expected2 = base / "test.txt"
+            assert result2 == expected2.resolve()
+    
+    def test_expand_path_user_home(self):
+        """Test expanding paths with user home (~)."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            context = CLIContext(cwd=base)
+            
+            # Test user home expansion
+            result = _expand_path(base, "~/test.txt")
+            expected = Path.home() / "test.txt"
+            assert result == expected.resolve()
+    
+    def test_expand_path_empty(self):
+        """Test expanding empty path."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            context = CLIContext(cwd=base)
+            
+            # Test empty path
+            result = _expand_path(base, "")
+            assert result == base
+    
+    def test_expand_path_windows_drive_letter(self):
+        """Test expanding Windows drive letter paths."""
+        import os
+        if os.name == 'nt':  # Windows
+            with tempfile.TemporaryDirectory() as temp_dir:
+                base = Path(temp_dir)
+                context = CLIContext(cwd=base)
+                
+                # Test drive letter path (Windows specific)
+                drive_path = "C:\\test.txt"
+                result = _expand_path(base, drive_path)
+                expected = Path(drive_path)
+                assert result == expected.resolve()
+    
+    def test_expand_path_backslashes(self):
+        """Test that backslashes in paths are handled correctly."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            context = CLIContext(cwd=base)
+            
+            # Test path with backslashes (should work on both platforms)
+            path_with_backslash = "subdir\\test.txt"
+            result = _expand_path(base, path_with_backslash)
+            expected = base / "subdir" / "test.txt"
+            assert result == expected.resolve()

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -4,6 +4,169 @@ import pytest
 import tempfile
 from pathlib import Path
 from src.workflows.modernization_pipeline import ModernizationPipeline
+from src.workflows.batch_pipeline import discover_cobol_files
+
+
+class TestDiscoverCobolFiles:
+    """Tests for discover_cobol_files function."""
+    
+    def test_discover_single_file(self):
+        """Test discovering a single COBOL file."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.cbl', delete=False) as f:
+            f.write("SAMPLE COBOL")
+            temp_file = Path(f.name)
+        
+        try:
+            result = discover_cobol_files(temp_file)
+            assert len(result) == 1
+            assert result[0] == temp_file
+        finally:
+            temp_file.unlink()
+    
+    def test_discover_directory(self):
+        """Test discovering COBOL files in a directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create COBOL files
+            cbl1 = temp_path / "test1.cbl"
+            cbl2 = temp_path / "test2.CBL"
+            cbl1.write_text("COBOL1")
+            cbl2.write_text("COBOL2")
+            
+            # Create non-COBOL file
+            txt_file = temp_path / "readme.txt"
+            txt_file.write_text("TEXT")
+            
+            result = discover_cobol_files(temp_path)
+            assert len(result) == 2
+            assert cbl1 in result
+            assert cbl2 in result
+            assert txt_file not in result
+    
+    def test_discover_with_pattern(self):
+        """Test discovering COBOL files with glob pattern."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create files in subdirectory
+            subdir = temp_path / "src"
+            subdir.mkdir()
+            
+            cbl1 = subdir / "main.cbl"
+            cbl2 = subdir / "utils.cbl"
+            cbl3 = temp_path / "root.cbl"
+            
+            cbl1.write_text("MAIN")
+            cbl2.write_text("UTILS")
+            cbl3.write_text("ROOT")
+            
+            # Test pattern search
+            result = discover_cobol_files(temp_path, pattern="src/*.cbl")
+            assert len(result) == 2
+            assert cbl1 in result
+            assert cbl2 in result
+            assert cbl3 not in result
+    
+    def test_discover_with_limit(self):
+        """Test discovering COBOL files with limit."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create multiple COBOL files
+            files = []
+            for i in range(5):
+                cbl_file = temp_path / f"test{i}.cbl"
+                cbl_file.write_text(f"COBOL{i}")
+                files.append(cbl_file)
+            
+            # Sort by size (they should all be same size, so order may vary)
+            result = discover_cobol_files(temp_path, limit=3)
+            assert len(result) == 3
+            assert all(f in files for f in result)
+    
+    def test_discover_file_list(self):
+        """Test discovering COBOL files from a file list."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create COBOL files
+            cbl1 = temp_path / "file1.cbl"
+            cbl2 = temp_path / "file2.cbl"
+            cbl1.write_text("FILE1")
+            cbl2.write_text("FILE2")
+            
+            # Create file list
+            file_list = temp_path / "files.txt"
+            file_list.write_text("file1.cbl\nfile2.cbl\n")
+            
+            result = discover_cobol_files(file_list)
+            assert len(result) == 2
+            assert cbl1 in result
+            assert cbl2 in result
+    
+    def test_discover_file_list_relative_paths(self):
+        """Test discovering COBOL files from file list with relative paths."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create subdirectory
+            subdir = temp_path / "cobol"
+            subdir.mkdir()
+            
+            # Create COBOL files
+            cbl1 = subdir / "program.cbl"
+            cbl1.write_text("PROGRAM")
+            
+            # Create file list in root directory referencing file in subdirectory
+            file_list = temp_path / "files.txt"
+            file_list.write_text("cobol/program.cbl\n")
+            
+            result = discover_cobol_files(file_list)
+            assert len(result) == 1
+            assert result[0] == cbl1
+    
+    def test_discover_windows_drive_letter(self):
+        """Test that function handles absolute paths with drive letters (Windows)."""
+        # This test will only run on Windows, but we can test the logic
+        import os
+        if os.name == 'nt':  # Windows
+            # Create a file with absolute path
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.cbl', delete=False) as f:
+                f.write("WINDOWS COBOL")
+                temp_file = Path(f.name)
+            
+            try:
+                # Test that absolute path works
+                result = discover_cobol_files(temp_file)
+                assert len(result) == 1
+                assert result[0] == temp_file
+                assert temp_file.is_absolute()
+            finally:
+                temp_file.unlink()
+    
+    def test_discover_case_insensitive_extensions(self):
+        """Test that function finds COBOL files with various case extensions."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create files with different case extensions
+            cbl1 = temp_path / "test1.cbl"
+            cbl2 = temp_path / "test2.CBL"
+            cbl3 = temp_path / "test3.cob"
+            cbl4 = temp_path / "test4.COB"
+            
+            cbl1.write_text("CBL")
+            cbl2.write_text("CBL_UPPER")
+            cbl3.write_text("COB")
+            cbl4.write_text("COB_UPPER")
+            
+            result = discover_cobol_files(temp_path)
+            assert len(result) == 4
+            assert cbl1 in result
+            assert cbl2 in result
+            assert cbl3 in result
+            assert cbl4 in result
 
 
 class TestModernizationPipeline:


### PR DESCRIPTION
### Changes made to address issue #42
- Modified [batch_pipeline.py] - Changed signature to accept `Path` objects, added proper pattern handling and relative path resolution
- Modified [interactive_shell.py - Improved cross-platform path resolution with user expansion and quote handling  
- Updated [.github/workflows/CI.yml] to include `windows-latest` in test matrix
- Created Windows-specific tests in [test_workflows.py] and [test_cli.py] for drive letters, backslashes and case-insensitive extensions
- Modified [main.py] to pass `Path` objects instead of strings
